### PR TITLE
sonata-project/admin-bundle requirement from 2.x to 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "sonata-project/admin-bundle": "~2.2,>=2.2.2",
+        "sonata-project/admin-bundle": "^3.0",
         "doctrine/dbal": "~2.2"
     },
     "autoload": {
@@ -22,7 +22,7 @@
     "target-dir": "CoopTilleuls/Bundle/AclSonataAdminExtensionBundle",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.3.x-dev"
+            "dev-master": "dev-fixcomposer"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "sonata-project/admin-bundle": "^3.0",
+        "sonata-project/admin-bundle": "^2.2.2|^3.0",
         "doctrine/dbal": "~2.2"
     },
     "autoload": {
@@ -22,7 +22,7 @@
     "target-dir": "CoopTilleuls/Bundle/AclSonataAdminExtensionBundle",
     "extra": {
         "branch-alias": {
-            "dev-master": "dev-fixcomposer"
+            "dev-master": "2.0.x-dev"
         }
     }
 }


### PR DESCRIPTION
Please, update the composer.json to ensure compatibility with sonata-project/admin-bundle:"^3.0" .
The code of Acl Sonata Extension Bundle was tested on SF 2.8.7 with admin-bundle 3.3 and it works perfectly.